### PR TITLE
allow zero timeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func roundToSeconds(d time.Duration) time.Duration {
 
 func main() {
 	flag.Parse()
-	if *flagP <= 0 || *flagTimeout <= 0 || len(flag.Args()) == 0 {
+	if *flagP <= 0 || *flagTimeout < 0 || len(flag.Args()) == 0 {
 		flag.Usage()
 		os.Exit(1)
 	}


### PR DESCRIPTION
This is what caused the several hundred stress failures, since we now default the timeout to zero.