### PR TITLE
stress: skip merging when there are no artifacts to merge

### DIFF
--- a/main.go
+++ b/main.go
@@ -271,6 +271,10 @@ func run() error {
 
 			// Merge sharded artifacts.
 			for env, mergeProgram := range shardableArtifacts {
+				if len(filesToMerge[env]) == 0 {
+					fmt.Printf("stress: skipping merge for artifact %s\n", env)
+					continue
+				}
 				output, err := os.Create(os.Getenv(env))
 				if err != nil {
 					return err


### PR DESCRIPTION
If no tests successfully complete then there will be nothing to merge
and just calling into the merge program may therefore fail. In this case
it's appropriate to skip the merge.